### PR TITLE
Abstract dbus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module dbus-lib
+module lib
 
 go 1.14
 


### PR DESCRIPTION
I felt that DBus was an internal detail, let's keep the lib clean of that detail.
To do this the repo should be renamed "lib" as well. We are already in the "unix-streamdeck" org so it should be clear.